### PR TITLE
rsvc.py: Dendrite 0.13.3 supports version 11

### DIFF
--- a/rsvc.py
+++ b/rsvc.py
@@ -87,7 +87,7 @@ minimum_version = {
         "8": semver.parse("0.8.6"),  # actually added in 0.5.1, but only marked as stable in 0.8.6
         "9": semver.parse("0.8.6"),
         "10": semver.parse("0.8.7"),
-        "11": False,
+        "11": semver.parse("0.13.3"),
     },
     "Conduit": {
         "1": False,

--- a/rsvc.py
+++ b/rsvc.py
@@ -44,9 +44,9 @@ class TestError(Exception):
 known_room_versions = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}
 versions_updated = "2023-09-30"
 latest_known_version = {
-    "Synapse": packaging.version.parse("1.89.0"),
-    "Dendrite": semver.parse("0.13.1"),
-    "Conduit": semver.parse("0.5.0"),
+    "Synapse": packaging.version.parse("1.93.0"),
+    "Dendrite": semver.parse("0.13.3"),
+    "Conduit": semver.parse("0.6.0"),
 }
 
 minimum_version = {

--- a/rsvc.py
+++ b/rsvc.py
@@ -42,7 +42,7 @@ class TestError(Exception):
 
 
 known_room_versions = {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}
-versions_updated = "2023-08-07"
+versions_updated = "2023-09-30"
 latest_known_version = {
     "Synapse": packaging.version.parse("1.89.0"),
     "Dendrite": semver.parse("0.13.1"),


### PR DESCRIPTION
Ref: https://github.com/matrix-org/dendrite/releases/tag/v0.13.3